### PR TITLE
Update to use include_tasks instead include. Deprecation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,11 +9,11 @@
   when: chrome_package is not defined
 
 # Setup/install tasks.
-- include: setup.yml
-  static: no
+- include_tasks: setup.yml
+  # static: no
   when: ansible_architecture == 'x86_64'
 
 # Setup/install tasks.
-- include: configure.yml
-  static: no
+- include_tasks: configure.yml
+  # static: no
   when: ansible_architecture == 'x86_64'

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,7 +1,7 @@
 ---
-- include: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
-  static: no
+  # static: no
 
 - name: Delete package file
   file:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Only to remove deprecation warnings

#### Why?

Which problem does the PR fix? (remove this section if you linked an issue above)

#### Example Usage

```yaml
# If you added new features, show examples of how to use them here
# (remove this section if not a new feature)
vagrant_plugins:
  - # ..
```

#### BC Breaks/Deprecations

[DEPRECATION WARNING]: The use of 'static' has been deprecated. Use 'import_tasks' for static inclusion, or 'include_tasks' for dynamic 
inclusion. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.

#### To Do

- [ ] Create documentation
